### PR TITLE
solution to run-build issue

### DIFF
--- a/week4/dbt-project/models/core/dim_zones.sql
+++ b/week4/dbt-project/models/core/dim_zones.sql
@@ -1,4 +1,4 @@
-{{ config(materialized='view') }}
+{{ config(materialized='table') }}
 
 select 
     locationid, 


### PR DESCRIPTION
A final solution to the run-build dilemma I had. It was due to a subtle error in the config macro. It was set to `view` instead of `table`.